### PR TITLE
Enhance `represent`

### DIFF
--- a/src/matrixbases.jl
+++ b/src/matrixbases.jl
@@ -47,7 +47,12 @@ end
 length(itr::HermitianBasisIterator) = itr.dim^2
 
 function represent(basis::T, m::Matrix{<:Number}) where T<:AbstractMatrixBasis
-    tr.([m] .* basis.iterator) 
+    real.(tr.([m] .* basis.iterator))
+end
+
+function represent(basis::Type{T}, m::Matrix{<:Number}) where T<:AbstractMatrixBasis
+    d = size(m, 1)
+    represent(basis{typeof(m)}(d), m)
 end
 
 function combine(basis::T, v::Vector{<:Number}) where T<:AbstractMatrixBasis

--- a/test/matrixbases.jl
+++ b/test/matrixbases.jl
@@ -8,7 +8,7 @@ end
 
 @testset "represent, combine" begin
     d = 4
-    A = reshape(collect(1:16), d, d)
+    A = reshape(collect(1:16), d, d) + reshape(collect(1:16), d, d)'
     vA = represent(HermitianBasis{Matrix{ComplexF64}}(d), A)
     Ap = combine(HermitianBasis{Matrix{ComplexF64}}(d), vA)
     @test A ≈ Ap
@@ -18,7 +18,7 @@ end
     @test B ≈ Bp
 
     vB = represent(HermitianBasis{Matrix{ComplexF32}}(d), B)
-    @test eltype(vB) == ComplexF32
+    @test eltype(vB) == Float32
 end
 
 end


### PR DESCRIPTION
`represent` can now take just a subtype of `AbstractMatrixBasis` and constructs the basis, infering the matrix type and diemnsions